### PR TITLE
Make zimHttpServer32 compatible with AVM Fritz!Box routers (freetz)

### DIFF
--- a/README.avm.perl
+++ b/README.avm.perl
@@ -1,0 +1,38 @@
+As an alternative to building perl in-tree, (see
+https://github.com/dirk-dhu/freetz/tree/master/make/perl
+), here are the steps to do this manually, if your
+freetz distribution lacks make/perl package or have
+trouble using the automated build.
+
+To cross-compile perl and integrate it manually
+into a freetz build, here is a rough guideline,
+tried and tested:
+
+  perl-5.26.2.tar.gz
+  perl-cross-1.1.9.tar.gz   (unpack over perl-5.26.2 source)
+
+compile freetz with the following line in .config to setup all the links for perl
+---------------------------------------------------------------------------------
+  EXTERNAL_OWN_FILES="/usr/bin/corelist /usr/bin/cpan /usr/bin/enc2xs /usr/bin/encguess /usr/bin/h2ph /usr/bin/h2xs /usr/bin/instmodsh /usr/bin/json_pp /usr/bin/libnetcfg /usr/bin/perl /usr/bin/perlbug /usr/bin/perldoc /usr/bin/perlivp /usr/bin/perlthanks /usr/bin/piconv /usr/bin/pl2pm /usr/bin/pod2html /usr/bin/pod2man /usr/bin/pod2text /usr/bin/pod2usage /usr/bin/podchecker /usr/bin/podselect /usr/bin/prove /usr/bin/ptar /usr/bin/ptardiff /usr/bin/ptargrep /usr/bin/shasum /usr/bin/splain /usr/bin/xsubpp /usr/bin/zipdetails /usr/lib/perl5"
+
+compile perl and integrate into freetz image using
+---------------------------------------------
+  cd perl-src-dir
+
+  export PATH="$PATH:$FREETZDIR/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/bin/"
+
+  ./configure --target=mips-linux-uclibc --target-tools-prefix=mips-linux-uclibc
+  make
+  make DESTDIR=$FREETZDIR/build/modified/external
+
+  # do not distribute man page to embedded system
+  rm -rvf $FREETZDIR/build/modified/external/usr/share/man
+
+  # repack image to reflect modified/external state
+  FREETZ_FWMOD_SKIP_UNPACK=y FREETZ_FWMOD_SKIP_MODIFY=y make firmware-nocompile
+
+
+The resulting firmware will work to run zimHttpServer32 on Fritz!Box
+router hardware in combination with the machine-endianess-tolerant
+zimHttpServer.pl in this repo-sitory.
+

--- a/README.avm.xzutils
+++ b/README.avm.xzutils
@@ -1,0 +1,15 @@
+    - Busybox (tested 1.24 and current 1.28) xz applet does not work
+      (reports "corrupted data" to the terminal when applied to the
+      xz data extracted from the zim file by zimHttpServer.pl script)
+
+    - xz from xz-utils works, but only in combination with swap
+      enabled (xz fragments in zim files may have large dict size,
+      expect the xz decompressor to use ~65mb to decompress; because
+      of this 7270 and older boxes may not be suited to serve a zim)
+
+    - thus minimum RAM requirement is 128MB to get heavily compressed
+      zim files working with AVM Fritz!Box routers
+
+    - the script expects native xz binary in /mod/external/usr/bin,
+      need to change the location in the script, if xz-utils is not
+      externalized

--- a/README.avm.xzutils
+++ b/README.avm.xzutils
@@ -1,15 +1,10 @@
-    - Busybox (tested 1.24 and current 1.28) xz applet does not work
-      (reports "corrupted data" to the terminal when applied to the
-      xz data extracted from the zim file by zimHttpServer.pl script)
+    - Busybox (tested 1.24 and current 1.28) xz applet appears to not
+      work (reports "corrupted data" to the terminal) when applied to
+      the xz data extracted from zim files, _but_ the error message
+      is wrong - if enough RAM (physical and swap) is available the
+      xz applet will work just as well as the binary from xz-utils.
 
-    - xz from xz-utils works, but only in combination with swap
-      enabled (xz fragments in zim files may have large dict size,
-      expect the xz decompressor to use ~65mb to decompress; because
-      of this 7270 and older boxes may not be suited to serve a zim)
-
-    - thus minimum RAM requirement is 128MB to get heavily compressed
-      zim files working with AVM Fritz!Box routers
-
-    - the script expects native xz binary in /mod/external/usr/bin,
-      need to change the location in the script, if xz-utils is not
-      externalized
+    - Thus minimum RAM requirement is 128 MB (physical, and another
+      64 to 128 MB using swap) to serve heavily compressed zim files
+      from AVM Fritz!Box routers, i.e. it may not work with 7270 and
+      older devices

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+
+This repo is DEPRECATED and here for reference purpose only, it may be deleted from github at any time in the future.
+
+The clone was originally done with the intention
+of integration into freetz, thus the content of
+the few commits in this repo has basically moved
+to
+https://github.com/cm8/freetz/commits/make/zimhttpserver
+
+Due to the way freetz packages work, there is not
+a full clone - make/zimhttpserver/zimhttpserver.mk
+rather refers to the original upstream repo,
+instead of cloning it fully into freetz. The
+reason for freetz to do it this way is, that
+it is unclear if a clone is needed until the
+user has configured freetz build system.
+
+After some grace period, /this/ fork will probably
+be deleted, because the original intention of
+integration into freetz is now finished. If you
+have bookmarked it for some reason, take a look
+at
+https://github.com/cm8/freetz/commit/a89bb115d2d9ec47f7ad85dc3ec24a286b6b1a64
+
+This commit basically squashes the changes done
+to this repo since fork time.

--- a/zimHttpServer.pl
+++ b/zimHttpServer.pl
@@ -13,22 +13,21 @@ use Socket;
 use List::Util qw( min max );
 
 my %article;
-
-my $UNAME=`uname -m`;
-chomp($UNAME);
-print "UNAME = [$UNAME]\n";
 my $XZ;
-if (-e "/mod/external/usr/bin/xz") {
-    $XZ="/mod/external/usr/bin/xz";
-    print "Detected standalone xz, using local xz binary at $XZ\n";
-} else {
-if (-e "./$UNAME/xz") {
-    $XZ="./$UNAME/xz";
-    print "Detected $UNAME, using local xz binary at $XZ\n";
-} else {
-    print "Using system xz binary\n";
+if (-e "/usr/bin/xz" or -e "/bin/xz") {
     $XZ="xz";
-}
+    print "Using system xz binary.\n";
+} else {
+    my $UNAME=`uname -m`;
+    chomp($UNAME);
+    print "UNAME = [$UNAME]\n";
+
+    if (-e "./$UNAME/xz") {
+        $XZ="./$UNAME/xz";
+        print "Using local xz binary at $XZ\n";
+    } else {
+        die "No suitable xz decompressor found\n";
+    }
 }
 
 # open «file.zim». For more information see internet «openzim.org»


### PR DESCRIPTION
AVM Fritz!Box products are big endian machines, while the integers
and shorts in the zim file format are stored in little endian byte
order.

Essentially, this patch adds robustness to read the zim file format,
regardless of the endianess of the target machine that executes perl
and this script.  For this, unpack("I") and unpack("s") statements
were replaced.

